### PR TITLE
fix(cmake): upgrade min cmake version to match cmake 4.0 requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 project(PER C CXX)
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/cmake/templates/PERConfig.cmake.in
+++ b/cmake/templates/PERConfig.cmake.in
@@ -141,20 +141,18 @@ set(PER_INCLUDE_DIRS "@PER_INCLUDE_DIRS_CONFIGCMAKE@")
 # Tells the user project PER library name
 set(PER_LIBRARIES ${PER_LIBS})
 
-# need to be improved
-if(POLICY CMP0024)
-  # Fix to prevent multiple includes
-  if(NOT TARGET per_core)
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0024 OLD)
-    # Our library dependencies (contains definitions for IMPORTED targets)
-    include("${CMAKE_CURRENT_LIST_DIR}/PERModules.cmake")
-    cmake_policy(POP)
-  endif()
-else()
-  # Fix for cmake 2.8.7 to prevent multiple includes
-  if(NOT TARGET per_core)
-    # Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET per_core)
+  if(${CMAKE_VERSION} VERSION_LESS "4.0")
+    if(POLICY CMP0024)
+      cmake_policy(PUSH)
+      cmake_policy(SET CMP0024 NEW)
+      include("${CMAKE_CURRENT_LIST_DIR}/PERModules.cmake")
+      cmake_policy(POP)
+    else()
+      include("${CMAKE_CURRENT_LIST_DIR}/PERModules.cmake")
+    endif()
+  else()
+    # CMake 4.0+ - CMP0024 is always NEW, no need to set or push
     include("${CMAKE_CURRENT_LIST_DIR}/PERModules.cmake")
   endif()
 endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(PER-examples)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED)
 

--- a/example/CartesianPolynomial2FisheyeOpenCV/CMakeLists.txt
+++ b/example/CartesianPolynomial2FisheyeOpenCV/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-CartesianPolynomial2FisheyeOpenCV)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/example/FisheyeEquidistant2OmniCameraModelConversion/CMakeLists.txt
+++ b/example/FisheyeEquidistant2OmniCameraModelConversion/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-FisheyeEquidistant2OmniCameraModelConversion)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/example/Omni2PolyCartCameraModelConversion/CMakeLists.txt
+++ b/example/Omni2PolyCartCameraModelConversion/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-Omni2PolyCartCameraModelConversion)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/example/RationalPolynomial2FisheyeOpenCV/CMakeLists.txt
+++ b/example/RationalPolynomial2FisheyeOpenCV/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-RationalPolynomial2FisheyeOpenCV)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/example/RationalPolynomial2PlumbBoCameraModelConversion/CMakeLists.txt
+++ b/example/RationalPolynomial2PlumbBoCameraModelConversion/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-RationalPolynomial2PlumbBoCameraModelConversion)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/example/pointPerspectiveProjection/CMakeLists.txt
+++ b/example/pointPerspectiveProjection/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-pointPerspectiveProjection)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_features)
 

--- a/example/saveAndLoadStereocameraModelXML/CMakeLists.txt
+++ b/example/saveAndLoadStereocameraModelXML/CMakeLists.txt
@@ -25,7 +25,7 @@
 
 project(example-saveAndLoadStereocameraModelXML)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 find_package(PER REQUIRED per_core per_io)
 

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -84,11 +84,6 @@ if(USE_OPENCV)
     # ReleaseWithDebugInfo was requested to detect libopencv-devel under Fedora 20
     # RelWithDebugInfo was requested to detect ros-hydro-opencv2 2.4.9 under Ubuntu 12.04 LTS with ROS hydro
     set(config_ "NONE" "RELEASE" "DEBUG" "RELEASEWITHDEBINFO" "RELWITHDEBINFO")
-    if(POLICY CMP0045)
-      # Fix Error on non-existent target in get_target_property for 3rd party location extraction
-      cmake_policy(PUSH)
-      cmake_policy(SET CMP0045 OLD)
-    endif()
 
     foreach(component_ ${OpenCV_LIB_COMPONENTS})
       foreach(imp_config_ ${config_})
@@ -152,10 +147,6 @@ if(USE_OPENCV)
       endforeach()
     endforeach()
 
-    if(POLICY CMP0045)
-      # Fix Error on non-existent target in get_target_property for 3rd party location extraction
-      cmake_policy(POP)
-    endif()
     list(APPEND opt_libs "${OpenCV_LIBS}")
   else()
     # this should be an old OpenCV version that doesn't have the previous behavior


### PR DESCRIPTION
Helllo @GuicarMIS, @AntoineAndre ,

Please find here an update needed to compile with latest cmake (4.0) as they removed support for cmake < 3.5. 